### PR TITLE
fix documentation after renaming of rx_letters to rx_categories

### DIFF
--- a/doc/vikitasks.txt
+++ b/doc/vikitasks.txt
@@ -467,7 +467,7 @@ g:vikitasks_scan_patterns      (default: ['*.txt', '*.viki'])
       Nm               ... Tasks for the next N months (i.e. 31 days)
       week             ... Tasks for the next week (i.e. 7 days)
       month            ... Tasks for the next month (i.e. 31 days)
-      .                ... Show some tasks (see |g:vikitasks#rx_letters| 
+      .                ... Show some tasks (see |g:vikitasks#rx_categories| 
                            and |g:vikitasks#rx_levels|)
       *                ... Show all tasks
 

--- a/plugin/vikitasks.vim
+++ b/plugin/vikitasks.vim
@@ -69,7 +69,7 @@ TLet g:vikitasks_scan_patterns = ['*.txt', '*.viki']
 "   Nm               ... Tasks for the next N months (i.e. 31 days)
 "   week             ... Tasks for the next week (i.e. 7 days)
 "   month            ... Tasks for the next month (i.e. 31 days)
-"   .                ... Show some tasks (see |g:vikitasks#rx_letters| 
+"   .                ... Show some tasks (see |g:vikitasks#rx_categories| 
 "                        and |g:vikitasks#rx_levels|)
 "   *                ... Show all tasks
 "


### PR DESCRIPTION
I am not sure if the file doc/vikitasks.txt is autocreated and by what tool, therefore I changed both.
This PR fixes a left over reference in the help file after renaming a variable.
